### PR TITLE
Support for multi root

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"url": "https://github.com/DotJoshJohnson/vscode-xml/issues"
 	},
 	"engines": {
-		"vscode": "^1.13.0",
+		"vscode": "^1.17.0",
 		"node": "^0.12.0"
 	},
 	"categories": [
@@ -58,32 +58,38 @@
                 "xmlTools.persistXPathQuery": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Remember the last XPath query used."
+                    "description": "Remember the last XPath query used.",
+                    "scope": "resource"
                 },
                 "xmlTools.removeCommentsOnMinify": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Remove XML comments when XML is minified."
+                    "description": "Remove XML comments when XML is minified.",
+                    "scope": "resource"
                 },
                 "xmlTools.splitXmlnsOnFormat": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Put each xmlns attribute on a new line when fromatting XML."
+                    "description": "Put each xmlns attribute on a new line when fromatting XML.",
+                    "scope": "resource"
                 },
                 "xmlTools.xqueryExecutionEngine": {
                     "type": "string",
                     "default": "",
-                    "description": "The full path to the execution engine executable."
+                    "description": "The full path to the execution engine executable.",
+                    "scope": "resource"
                 },
                 "xmlTools.xqueryExecutionArguments": {
                     "type": "array",
                     "default": ["-xquery", "$(script)", "-in", "$(input)", "-out", "$(input).output.xml"],
-                    "description": "Arguments to be passed to the execution engine. '$(script)' and '$(input)' refer to the XQuery script and input XML file, respectively."
+                    "description": "Arguments to be passed to the execution engine. '$(script)' and '$(input)' refer to the XQuery script and input XML file, respectively.",
+                    "scope": "resource"
                 },
                 "xmlTools.ignoreDefaultNamespace": {
                     "type": "boolean",
                     "default": true,
-                    "description": "Ignores default xmlns attribute when evaluating XPath."
+                    "description": "Ignores default xmlns attribute when evaluating XPath.",
+                    "scope": "resource"
                 }
             }
         },

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -12,7 +12,7 @@ const CFG_REMOVE_COMMENTS: string = "removeCommentsOnMinify";
 
 export class TextEditorCommands {
     static minifyXml(editor: vsc.TextEditor, edit: vsc.TextEditorEdit): void {
-        let removeComments: boolean = vsc.workspace.getConfiguration(CFG_SECTION).get<boolean>(CFG_REMOVE_COMMENTS, false);
+        let removeComments: boolean = vsc.workspace.getConfiguration(CFG_SECTION, editor.document.uri).get<boolean>(CFG_REMOVE_COMMENTS, false);
         
         let range: vsc.Range = RangeUtil.getRangeForDocument(editor.document);
         

--- a/src/providers/Execution.ts
+++ b/src/providers/Execution.ts
@@ -15,8 +15,8 @@ export class XQueryExecutionProvider {
             return;
         }
         
-        let executable = vsc.workspace.getConfiguration(CFG_SECTION).get<string>(CFG_XQEXEC, null);
-        let args = vsc.workspace.getConfiguration(CFG_SECTION).get<string[]>(CFG_XQARGS, []);
+        let executable = vsc.workspace.getConfiguration(CFG_SECTION, editor.document.uri).get<string>(CFG_XQEXEC, null);
+        let args = vsc.workspace.getConfiguration(CFG_SECTION, editor.document.uri).get<string[]>(CFG_XQARGS, []);
         
         if (!executable || executable == "") {
             let action = await vsc.window.showWarningMessage("An XQuery execution engine has not been defined.", "Define Now");
@@ -89,14 +89,16 @@ export class XQueryExecutionProvider {
             
             args[outputPathPos] = outputPath;
         }
-        
+
+        const project = vsc.workspace.getWorkspaceFolder(editor.document.uri) ? vsc.workspace.getWorkspaceFolder(editor.document.uri).uri.fsPath : '';
+
         // call out to the execution engine
         disposable = vsc.window.setStatusBarMessage("Executing XQuery Script...");
         args = args.map<string>((value: string) => {
             return value
                 .replace("$(script)", editor.document.uri.fsPath)
                 .replace("$(input)", inputFile.fsPath)
-                .replace("$(project)", vsc.workspace.rootPath);
+                .replace("$(project)", project);
         });
         
         try {

--- a/src/providers/Formatting.ts
+++ b/src/providers/Formatting.ts
@@ -17,7 +17,7 @@ export class XmlFormattingEditProvider implements vsc.DocumentFormattingEditProv
     }
     
     private _provideFormattingEdits(document: vsc.TextDocument, range: vsc.Range, options: vsc.FormattingOptions): vsc.TextEdit[] {
-        let splitNamespaces: boolean = vsc.workspace.getConfiguration(CFG_SECTION).get<boolean>(CFG_SPLIT_NAMESPACES, true);
+        let splitNamespaces: boolean = vsc.workspace.getConfiguration(CFG_SECTION, document.uri).get<boolean>(CFG_SPLIT_NAMESPACES, true);
         
         let formatterOptions: IXmlFormatterOptions = {
             preferSpaces: options.insertSpaces,

--- a/src/providers/XPath.ts
+++ b/src/providers/XPath.ts
@@ -15,7 +15,7 @@ export class XPathFeatureProvider {
         let memento: vsc.Memento = ext.WorkspaceState || ext.GlobalState;
         
         // get the xpath persistence setting
-        let persistQueries: boolean = vsc.workspace.getConfiguration(CFG_SECTION).get<boolean>(CFG_PERSIST_QUERY, true);
+        let persistQueries: boolean = vsc.workspace.getConfiguration(CFG_SECTION, editor.document.uri).get<boolean>(CFG_PERSIST_QUERY, true);
         
         // get the last query if there is one for this document
         // if not, try pulling the last query ran, regardless of document
@@ -53,7 +53,7 @@ export class XPathFeatureProvider {
         // showInputBox() will return undefined if the user dimissed the prompt
         if (query) {
             
-            let ignoreDefaultNamespace: boolean = vsc.workspace.getConfiguration(CFG_SECTION).get<boolean>(CFG_IGNORE_DEFAULT_XMLNS, true);
+            let ignoreDefaultNamespace: boolean = vsc.workspace.getConfiguration(CFG_SECTION, editor.document.uri).get<boolean>(CFG_IGNORE_DEFAULT_XMLNS, true);
             
             // run the query
             let xml: string = editor.document.getText();


### PR DESCRIPTION
This PR adds multi root support 
- Marking all config to be of scope "resource"
- Updating all `getConfiguration()` to get config for current folder.
- Replacing use of `vscode.workspace.rootPath` with current folder path

 Fixes #128