### PR TITLE
Added showExplorer flag to control registration of tree view data provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,11 @@
                     "type": "boolean",
                     "default": true,
                     "description": "Ignores default xmlns attribute when evaluating XPath."
+                },
+                "xmlTools.showExplorer": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Show the XML Document view in the explorer panel"
                 }
             }
         },

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -8,6 +8,8 @@ import { XmlTreeViewDataProvider } from "./providers/XmlTreeView";
 export var GlobalState: vsc.Memento;
 export var WorkspaceState: vsc.Memento;
 
+const CFG_SECTION: string = "xmlTools";
+const CFG_SHOW_EXPLORER: string = "showExplorer";
 const LANG_XML: string = "xml";
 const LANG_XSL: string = "xsl";
 const LANG_XQUERY: string = "xquery;"
@@ -42,9 +44,12 @@ export function activate(ctx: vsc.ExtensionContext) {
     );
 
     // add views
-    ctx.subscriptions.push(
-        vsc.window.registerTreeDataProvider("xmlTreeView", new XmlTreeViewDataProvider(ctx))
-    );
+    let showExplorer: boolean = vsc.workspace.getConfiguration(CFG_SECTION).get<boolean>(CFG_SHOW_EXPLORER, true);
+    if (showExplorer){
+        ctx.subscriptions.push(
+            vsc.window.registerTreeDataProvider("xmlTreeView", new XmlTreeViewDataProvider(ctx))
+        );
+    }
 }
 
 export function deactivate() {


### PR DESCRIPTION
Food for thought in response to issue #130 

Added new configuration setting contribution point to support inverting default behavior. For projects that specifically need/want an XML panel by default, a workspace setting can be used to override the global default.