### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -63,7 +63,7 @@ export function deactivate() {
 }
 
 function _handleContextChange(editor: vsc.TextEditor): void {
-    if (!editor || !editor.document) {
+    if (!editor || !editor.document || editor.document.uri.scheme !== "file") {
         return;
     }
     

--- a/src/Extension.ts
+++ b/src/Extension.ts
@@ -8,9 +8,16 @@ import { XmlTreeViewDataProvider } from "./providers/XmlTreeView";
 export var GlobalState: vsc.Memento;
 export var WorkspaceState: vsc.Memento;
 
-const LANG_XML: string = "xml";
-const LANG_XSL: string = "xsl";
-const LANG_XQUERY: string = "xquery;"
+function createSelector(language: string): vsc.DocumentFilter[] {
+    return [
+        { language, scheme: "file" },
+        { language, scheme: "untitled" },
+    ];
+}
+
+const SELECTOR_XML_XSL: vsc.DocumentSelector = [...createSelector("xml"), ...createSelector("xsl")];
+const SELECTOR_XQUERY: vsc.DocumentSelector = createSelector("xquery");
+
 const MEM_QUERY_HISTORY: string = "xpathQueryHistory";
 
 export function activate(ctx: vsc.ExtensionContext) {
@@ -29,10 +36,10 @@ export function activate(ctx: vsc.ExtensionContext) {
 	
 	// register language feature providers
     ctx.subscriptions.push(
-        vsc.languages.registerDocumentFormattingEditProvider([LANG_XML, LANG_XSL], new XmlFormattingEditProvider()),
-        vsc.languages.registerDocumentRangeFormattingEditProvider([LANG_XML, LANG_XSL], new XmlFormattingEditProvider()),
+        vsc.languages.registerDocumentFormattingEditProvider(SELECTOR_XML_XSL, new XmlFormattingEditProvider()),
+        vsc.languages.registerDocumentRangeFormattingEditProvider(SELECTOR_XML_XSL, new XmlFormattingEditProvider()),
         
-        vsc.languages.registerCompletionItemProvider(LANG_XQUERY, new XQueryCompletionItemProvider(), ":", "$")
+        vsc.languages.registerCompletionItemProvider(SELECTOR_XQUERY, new XQueryCompletionItemProvider(), ":", "$")
     );
     
     // listen to editor events (for linting)

--- a/src/providers/XmlTreeView.ts
+++ b/src/providers/XmlTreeView.ts
@@ -23,7 +23,7 @@ export class XmlTreeViewDataProvider implements vsc.TreeDataProvider<Node> {
         return vsc.window.activeTextEditor || null;
     }
 
-    getChildren(element?: Node): Node[] {
+    getChildren(element?: Element): Node[] {
         if (!this._xmlDocument) {
             this._refreshTree();
         }
@@ -41,7 +41,7 @@ export class XmlTreeViewDataProvider implements vsc.TreeDataProvider<Node> {
         }
     }
 
-    getTreeItem(element: Node): vsc.TreeItem {
+    getTreeItem(element: Element): vsc.TreeItem {
         let treeItem = new vsc.TreeItem(element.localName);
 
         if (this._getChildAttributeArray(element).length > 0) {
@@ -66,7 +66,7 @@ export class XmlTreeViewDataProvider implements vsc.TreeDataProvider<Node> {
         return treeItem;
     }
 
-    private _getChildAttributeArray(node: Node): Node[] {
+    private _getChildAttributeArray(node: Element): Node[] {
         if (!node.attributes) {
             return [];
         }


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for XML/XSL/XQuery, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the XML extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*