### PR TITLE
Fixes typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 * **`xmlTools.ignoreDefaultNamespace`:** Ignore default xmlns attributes when evaluating XPath.
 * **`xmlTools.persistXPathQuery`:** Remember the last XPath query used.
 * **`xmlTools.removeCommentsOnMinify`:** Remove XML comments during minification.
-* **`xmlTools.splitAttributesOnFormat`:** Put each attribute on a new line when formatting XML. Overrides `xmlTools.splitXmlsOnFormat` if set to `true`. (V2 Formatter Only)
+* **`xmlTools.splitAttributesOnFormat`:** Put each attribute on a new line when formatting XML. Overrides `xmlTools.splitXmlnsOnFormat` if set to `true`. (V2 Formatter Only)
 * **`xmlTools.splitXmlnsOnFormat`:** Put each xmlns attribute on a new line when formatting XML.
 * **`xmlTools.xmlFormatterImplementation`:** Supported XML Formatters: `classic`, `v2`.
 * **`xmlTools.xqueryExecutionArguments`:** Arguments to be passed to the XQuery execution engine.

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
                 "xmlTools.splitAttributesOnFormat": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Put each attribute on a new line when formatting XML. Overrides `xmlTools.splitXmlsOnFormat` if set to `true`.",
+                    "description": "Put each attribute on a new line when formatting XML. Overrides `xmlTools.splitXmlnsOnFormat` if set to `true`.",
                     "scope": "resource"
                 },
                 "xmlTools.splitXmlnsOnFormat": {


### PR DESCRIPTION
Fixes typo in property `xmlTools.splitXmlnsOnFormat` which is incorrectly referred as `xmlTools.splitXmlsOnFormat` in documentation.