### PR TITLE
Added XSLT Transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * [XQuery Linting](https://github.com/DotJoshJohnson/vscode-xml/wiki/xquery-linting)
 * [XQuery Execution](https://github.com/DotJoshJohnson/vscode-xml/wiki/xquery-script-execution)
 * [XQuery Code Completion](https://github.com/DotJoshJohnson/vscode-xml/wiki/xquery-code-completion)
+* XSLT Transformation
 
 ## Requirements
 * VS Code `1.22.2` or higher

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,65 @@
 {
     "name": "xml",
-    "version": "2.0.0-preview.2",
+    "version": "2.3.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+            "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+            "requires": {
+                "@babel/highlight": "^7.0.0"
+            }
+        },
+        "@babel/highlight": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "requires": {
+                "chalk": "^2.0.0",
+                "esutils": "^2.0.2",
+                "js-tokens": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "@types/mocha": {
             "version": "2.2.47",
             "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.47.tgz",
@@ -22,16 +78,26 @@
             "integrity": "sha1-xEKLDKhtO4gUdXJv2UmAs4onw4E=",
             "dev": true
         },
+        "acorn": {
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+            "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg=="
+        },
+        "acorn-jsx": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+            "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg=="
+        },
         "ajv": {
-            "version": "5.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "version": "6.6.1",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+            "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
             "dev": true,
             "requires": {
-                "co": "4.6.0",
-                "fast-deep-equal": "1.1.0",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.3.1"
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
             }
         },
         "ansi-align": {
@@ -39,7 +105,7 @@
             "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
             "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.0.0"
             }
         },
         "ansi-cyan": {
@@ -51,14 +117,10 @@
                 "ansi-wrap": "0.1.0"
             }
         },
-        "ansi-gray": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
-            "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
-            "dev": true,
-            "requires": {
-                "ansi-wrap": "0.1.0"
-            }
+        "ansi-escapes": {
+            "version": "3.1.0",
+            "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
         },
         "ansi-red": {
             "version": "0.1.1",
@@ -87,13 +149,21 @@
             "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
             "dev": true
         },
+        "append-buffer": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/append-buffer/-/append-buffer-1.0.2.tgz",
+            "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
+            "dev": true,
+            "requires": {
+                "buffer-equal": "^1.0.0"
+            }
+        },
         "argparse": {
             "version": "1.0.9",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
             "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-            "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -102,8 +172,8 @@
             "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-slice": "0.2.3"
+                "arr-flatten": "^1.0.1",
+                "array-slice": "^0.2.3"
             }
         },
         "arr-flatten": {
@@ -136,19 +206,13 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
             "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
-        },
-        "array-unique": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
             "dev": true
         },
         "arrify": {
@@ -158,16 +222,24 @@
             "dev": true
         },
         "asn1": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-            "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
-            "dev": true
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+            "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
+            "requires": {
+                "safer-buffer": "~2.1.0"
+            }
         },
         "assert-plus": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-            "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+            "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
             "dev": true
+        },
+        "astral-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg=="
         },
         "asynckit": {
             "version": "0.4.0",
@@ -176,15 +248,15 @@
             "dev": true
         },
         "aws-sign2": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-            "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
             "dev": true
         },
         "aws4": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-            "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+            "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
             "dev": true
         },
         "babel-code-frame": {
@@ -193,32 +265,24 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "balanced-match": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-            "dev": true
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "bcrypt-pbkdf": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-            "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+            "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
             "dev": true,
-            "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
-        },
-        "beeper": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
-            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
-            "dev": true
         },
         "block-stream": {
             "version": "0.0.9",
@@ -226,16 +290,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
-            }
-        },
-        "boom": {
-            "version": "2.10.1",
-            "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-            "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-            "dev": true,
-            "requires": {
-                "hoek": "2.16.3"
+                "inherits": "~2.0.0"
             }
         },
         "boxen": {
@@ -243,13 +298,13 @@
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
             "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
             "requires": {
-                "ansi-align": "2.0.0",
-                "camelcase": "4.1.0",
-                "chalk": "2.4.1",
-                "cli-boxes": "1.0.0",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "widest-line": "2.0.0"
+                "ansi-align": "^2.0.0",
+                "camelcase": "^4.0.0",
+                "chalk": "^2.0.1",
+                "cli-boxes": "^1.0.0",
+                "string-width": "^2.0.0",
+                "term-size": "^1.2.0",
+                "widest-line": "^2.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -257,7 +312,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -265,9 +320,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -280,7 +335,7 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -289,21 +344,9 @@
             "version": "1.1.8",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
-            "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
-            }
-        },
-        "braces": {
-            "version": "1.8.5",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-            "dev": true,
-            "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
             }
         },
         "browser-stdout": {
@@ -318,10 +361,16 @@
             "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
             "dev": true
         },
-        "buffer-from": {
+        "buffer-equal": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+            "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.0.tgz",
+            "integrity": "sha1-WWFrSYME1Var1GaWayLu2j7KX74=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
+            "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
         "builtin-modules": {
@@ -329,6 +378,19 @@
             "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
             "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
             "dev": true
+        },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "requires": {
+                "callsites": "^0.2.0"
+            }
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo="
         },
         "camelcase": {
             "version": "4.1.0",
@@ -341,9 +403,9 @@
             "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
         },
         "caseless": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
-            "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c=",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
             "dev": true
         },
         "chalk": {
@@ -352,22 +414,45 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.5",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             }
+        },
+        "chardet": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+            "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
         },
         "ci-info": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
             "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg=="
         },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A=="
+        },
         "cli-boxes": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
             "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "requires": {
+                "restore-cursor": "^2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
         },
         "clone": {
             "version": "0.2.0",
@@ -393,55 +478,17 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
-            },
-            "dependencies": {
-                "process-nextick-args": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-                    "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "2.3.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-                    "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "5.1.1"
-                    }
-                }
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
-        },
-        "co": {
-            "version": "4.6.0",
-            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-            "dev": true
         },
         "color-convert": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -449,24 +496,18 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
-        "color-support": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
-            "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
-            "dev": true
-        },
         "colors": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
             "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
         },
         "combined-stream": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-            "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -478,27 +519,29 @@
         "concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-            "dev": true
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "configstore": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
             "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
             "requires": {
-                "dot-prop": "4.2.0",
-                "graceful-fs": "4.1.11",
-                "make-dir": "1.2.0",
-                "unique-string": "1.0.0",
-                "write-file-atomic": "2.3.0",
-                "xdg-basedir": "3.0.0"
+                "dot-prop": "^4.1.0",
+                "graceful-fs": "^4.1.2",
+                "make-dir": "^1.0.0",
+                "unique-string": "^1.0.0",
+                "write-file-atomic": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             }
         },
         "convert-source-map": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
-            "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-            "dev": true
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
+            "integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "~5.1.1"
+            }
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -511,7 +554,7 @@
             "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
             "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
             "requires": {
-                "capture-stack-trace": "1.0.0"
+                "capture-stack-trace": "^1.0.0"
             }
         },
         "cross-spawn": {
@@ -519,18 +562,9 @@
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
             "requires": {
-                "lru-cache": "4.1.2",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
-            }
-        },
-        "cryptiles": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-            "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-            "dev": true,
-            "requires": {
-                "boom": "2.10.1"
+                "lru-cache": "^4.0.1",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "crypto-random-string": {
@@ -544,22 +578,8 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
+                "assert-plus": "^1.0.0"
             }
-        },
-        "dateformat": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
-            "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
-            "dev": true
         },
         "debug": {
             "version": "3.1.0",
@@ -576,13 +596,27 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "deep-extend": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
             "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w=="
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+        },
+        "define-properties": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+            "dev": true,
+            "requires": {
+                "object-keys": "^1.0.12"
+            }
         },
         "delayed-stream": {
             "version": "1.0.0",
@@ -596,12 +630,20 @@
             "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
             "dev": true
         },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "requires": {
+                "esutils": "^2.0.2"
+            }
+        },
         "dot-prop": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
             "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "duplexer": {
@@ -610,66 +652,31 @@
             "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
             "dev": true
         },
-        "duplexer2": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
-            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "1.1.14"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.1.14",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                    "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                }
-            }
-        },
         "duplexer3": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "duplexify": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.3.tgz",
-            "integrity": "sha512-g8ID9OroF9hKt2POf8YLayy+9594PzmM3scI00/uBXocX3TWNgoB67hjzkFe9ITAbQOne/lLdBxHXvYUM4ZgGA==",
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.1.tgz",
+            "integrity": "sha512-vM58DwdnKmty+FSPzT14K9JXb90H+j5emaR4KYbr2KTIz00WHGbWOe5ghQTx233ZCLZtrGDALzKwcjEtSt35mA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-            "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+            "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
             "dev": true,
-            "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "end-of-stream": {
@@ -678,7 +685,7 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -686,17 +693,220 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
+        "eslint": {
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.10.0.tgz",
+            "integrity": "sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==",
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "ajv": "^6.5.3",
+                "chalk": "^2.1.0",
+                "cross-spawn": "^6.0.5",
+                "debug": "^4.0.1",
+                "doctrine": "^2.1.0",
+                "eslint-scope": "^4.0.0",
+                "eslint-utils": "^1.3.1",
+                "eslint-visitor-keys": "^1.0.0",
+                "espree": "^5.0.0",
+                "esquery": "^1.0.1",
+                "esutils": "^2.0.2",
+                "file-entry-cache": "^2.0.0",
+                "functional-red-black-tree": "^1.0.1",
+                "glob": "^7.1.2",
+                "globals": "^11.7.0",
+                "ignore": "^4.0.6",
+                "imurmurhash": "^0.1.4",
+                "inquirer": "^6.1.0",
+                "js-yaml": "^3.12.0",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "levn": "^0.3.0",
+                "lodash": "^4.17.5",
+                "minimatch": "^3.0.4",
+                "mkdirp": "^0.5.1",
+                "natural-compare": "^1.4.0",
+                "optionator": "^0.8.2",
+                "path-is-inside": "^1.0.2",
+                "pluralize": "^7.0.0",
+                "progress": "^2.0.0",
+                "regexpp": "^2.0.1",
+                "require-uncached": "^1.0.3",
+                "semver": "^5.5.1",
+                "strip-ansi": "^4.0.0",
+                "strip-json-comments": "^2.0.1",
+                "table": "^5.0.2",
+                "text-table": "^0.2.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.6.1",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+                    "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "debug": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "js-yaml": {
+                    "version": "3.12.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
+                    "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+                },
+                "semver": {
+                    "version": "5.6.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+                    "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-scope": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.0.tgz",
+            "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
+            "requires": {
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
+            }
+        },
+        "eslint-utils": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q=="
+        },
+        "eslint-visitor-keys": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+            "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
+        },
+        "espree": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.0.tgz",
+            "integrity": "sha512-1MpUfwsdS9MMoN7ZXqAr9e9UKdVHDcvrJpyx7mm1WuQlx/ygErEQBzgi5Nh5qBHIoYweprhtMkTCb9GhcAIcsA==",
+            "requires": {
+                "acorn": "^6.0.2",
+                "acorn-jsx": "^5.0.0",
+                "eslint-visitor-keys": "^1.0.0"
+            }
+        },
         "esprima": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-            "dev": true
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+        },
+        "esquery": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+            "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+            "requires": {
+                "estraverse": "^4.0.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "requires": {
+                "estraverse": "^4.1.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
         },
         "esutils": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-            "dev": true
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
         },
         "event-stream": {
             "version": "3.3.4",
@@ -704,13 +914,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "execa": {
@@ -718,37 +928,19 @@
             "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
             "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
-            }
-        },
-        "expand-brackets": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-            "dev": true,
-            "requires": {
-                "is-posix-bracket": "0.1.1"
-            }
-        },
-        "expand-range": {
-            "version": "1.8.2",
-            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-            "dev": true,
-            "requires": {
-                "fill-range": "2.2.3"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "extend": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
             "dev": true
         },
         "extend-shallow": {
@@ -757,24 +949,17 @@
             "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
             "dev": true,
             "requires": {
-                "kind-of": "1.1.0"
+                "kind-of": "^1.1.0"
             }
         },
-        "extglob": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
-            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-            "dev": true,
+        "external-editor": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+            "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
             "requires": {
-                "is-extglob": "1.0.0"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                }
+                "chardet": "^0.7.0",
+                "iconv-lite": "^0.4.24",
+                "tmp": "^0.0.33"
             }
         },
         "extsprintf": {
@@ -783,55 +968,46 @@
             "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
             "dev": true
         },
-        "fancy-log": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
-            "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
-            "dev": true,
-            "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
-            }
-        },
         "fast-deep-equal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
             "dev": true
         },
         "fast-json-stable-stringify": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-            "dev": true
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
         },
         "fd-slicer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-            "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+            "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
-        "filename-regex": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-            "dev": true
-        },
-        "fill-range": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-            "dev": true,
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "escape-string-regexp": "^1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "requires": {
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "final-fs": {
@@ -839,29 +1015,29 @@
             "resolved": "https://registry.npmjs.org/final-fs/-/final-fs-1.6.1.tgz",
             "integrity": "sha1-1tzZLvb+T+jAer1WjHE1YQ7eMjY=",
             "requires": {
-                "node-fs": "0.1.7",
-                "when": "2.0.1"
+                "node-fs": "~0.1.5",
+                "when": "~2.0.1"
             }
         },
-        "first-chunk-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-1.0.0.tgz",
-            "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
-            "dev": true
+        "flat-cache": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.4.tgz",
+            "integrity": "sha512-VwyB3Lkgacfik2vhqR4uv2rvebqmDvFu4jlN/C1RzWoJEo8I7z4Q404oiqYCkq41mni8EzQnm95emU9seckwtg==",
+            "requires": {
+                "circular-json": "^0.3.1",
+                "graceful-fs": "^4.1.2",
+                "rimraf": "~2.6.2",
+                "write": "^0.2.1"
+            }
         },
-        "for-in": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
-        },
-        "for-own": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+        "flush-write-stream": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
+            "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "forever-agent": {
@@ -871,14 +1047,14 @@
             "dev": true
         },
         "form-data": {
-            "version": "2.1.4",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-            "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+            "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.6",
-                "mime-types": "2.1.18"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.6",
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -887,11 +1063,20 @@
             "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
             "dev": true
         },
+        "fs-mkdirp-stream": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-mkdirp-stream/-/fs-mkdirp-stream-1.0.0.tgz",
+            "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.11",
+                "through2": "^2.0.3"
+            }
+        },
         "fs.realpath": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-            "dev": true
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "fstream": {
             "version": "1.0.11",
@@ -899,26 +1084,22 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
-        "generate-function": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
-            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
             "dev": true
         },
-        "generate-object-property": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
-            "dev": true,
-            "requires": {
-                "is-property": "1.0.2"
-            }
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
         },
         "get-stream": {
             "version": "3.0.0",
@@ -931,65 +1112,20 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
+                "assert-plus": "^1.0.0"
             }
         },
         "glob": {
             "version": "7.1.2",
             "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-            "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
-            }
-        },
-        "glob-base": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-            "dev": true,
-            "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
-                    "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "2.0.1"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -998,73 +1134,26 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-5.3.5.tgz",
-            "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/glob-stream/-/glob-stream-6.1.0.tgz",
+            "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
-            },
-            "dependencies": {
-                "glob": {
-                    "version": "5.0.15",
-                    "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                    "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-                    "dev": true,
-                    "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "dev": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "dev": true,
-                    "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "dev": true
-                },
-                "through2": {
-                    "version": "0.6.5",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
-                    "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
-                    "dev": true,
-                    "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
-                    }
-                }
+                "extend": "^3.0.0",
+                "glob": "^7.1.1",
+                "glob-parent": "^3.1.0",
+                "is-negated-glob": "^1.0.0",
+                "ordered-read-streams": "^1.0.0",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.1.5",
+                "remove-trailing-separator": "^1.0.1",
+                "to-absolute-glob": "^2.0.0",
+                "unique-stream": "^2.0.2"
             }
         },
         "global-dirs": {
@@ -1072,34 +1161,30 @@
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
-        "glogg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.1.tgz",
-            "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
-            }
+        "globals": {
+            "version": "11.9.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
+            "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg=="
         },
         "got": {
             "version": "6.7.1",
             "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
             "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
             "requires": {
-                "create-error-class": "3.0.2",
-                "duplexer3": "0.1.4",
-                "get-stream": "3.0.0",
-                "is-redirect": "1.0.0",
-                "is-retry-allowed": "1.1.0",
-                "is-stream": "1.1.0",
-                "lowercase-keys": "1.0.1",
-                "safe-buffer": "5.1.1",
-                "timed-out": "4.0.1",
-                "unzip-response": "2.0.1",
-                "url-parse-lax": "1.0.0"
+                "create-error-class": "^3.0.0",
+                "duplexer3": "^0.1.4",
+                "get-stream": "^3.0.0",
+                "is-redirect": "^1.0.0",
+                "is-retry-allowed": "^1.0.0",
+                "is-stream": "^1.0.0",
+                "lowercase-keys": "^1.0.0",
+                "safe-buffer": "^5.0.1",
+                "timed-out": "^4.0.0",
+                "unzip-response": "^2.0.1",
+                "url-parse-lax": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -1119,9 +1204,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -1130,9 +1215,9 @@
             "integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
             "dev": true,
             "requires": {
-                "multimatch": "2.1.0",
-                "plugin-error": "0.1.2",
-                "streamfilter": "1.0.7"
+                "multimatch": "^2.0.0",
+                "plugin-error": "^0.1.2",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-gunzip": {
@@ -1141,8 +1226,8 @@
             "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "~0.6.5",
+                "vinyl": "~0.4.6"
             },
             "dependencies": {
                 "isarray": {
@@ -1157,10 +1242,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1175,29 +1260,29 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
         },
-        "gulp-remote-src": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/gulp-remote-src/-/gulp-remote-src-0.4.3.tgz",
-            "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
+        "gulp-remote-src-vscode": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/gulp-remote-src-vscode/-/gulp-remote-src-vscode-0.5.1.tgz",
+            "integrity": "sha512-mw4OGjtC/jlCWJFhbcAlel4YPvccChlpsl3JceNiB/DLJi24/UPxXt53/N26lgI3dknEqd4ErfdHrO8sJ5bATQ==",
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "node.extend": "^1.1.2",
+                "request": "^2.79.0",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.1"
             },
             "dependencies": {
                 "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
                 "clone-stats": {
@@ -1206,62 +1291,33 @@
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
-                "request": {
-                    "version": "2.79.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
-                    "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.7.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.18",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.2.1"
-                    }
-                },
                 "vinyl": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.0.2.tgz",
-                    "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
         },
-        "gulp-sourcemaps": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/gulp-sourcemaps/-/gulp-sourcemaps-1.6.0.tgz",
-            "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
+        "gulp-untar": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.7.tgz",
+            "integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.1",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "event-stream": "~3.3.4",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3",
+                "vinyl": "^1.2.0"
             },
             "dependencies": {
                 "clone": {
@@ -1282,120 +1338,32 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
-                    }
-                }
-            }
-        },
-        "gulp-symdest": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-symdest/-/gulp-symdest-1.1.0.tgz",
-            "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
-            "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
-            }
-        },
-        "gulp-untar": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/gulp-untar/-/gulp-untar-0.0.6.tgz",
-            "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
-            "dev": true,
-            "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
-            }
-        },
-        "gulp-util": {
-            "version": "3.0.8",
-            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
-            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
-            "dev": true,
-            "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
-                "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
-            },
-            "dependencies": {
-                "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
-                    "dev": true
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "object-assign": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
-                    "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
-                    "dev": true
-                },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
-                    "dev": true
-                },
-                "vinyl": {
-                    "version": "0.5.3",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
-                    "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
-                    "dev": true,
-                    "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
             }
         },
         "gulp-vinyl-zip": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.0.tgz",
-            "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/gulp-vinyl-zip/-/gulp-vinyl-zip-2.1.2.tgz",
+            "integrity": "sha512-wJn09jsb8PyvUeyFF7y7ImEJqJwYy40BqL9GKfJs6UGpaGW9A+N68Q+ajsIpb9AeR6lAdjMbIdDPclIGo1/b7Q==",
             "dev": true,
             "requires": {
                 "event-stream": "3.3.4",
-                "queue": "4.4.2",
-                "through2": "2.0.3",
-                "vinyl": "2.1.0",
-                "vinyl-fs": "2.4.4",
-                "yauzl": "2.9.1",
-                "yazl": "2.4.3"
+                "queue": "^4.2.1",
+                "through2": "^2.0.3",
+                "vinyl": "^2.0.2",
+                "vinyl-fs": "^3.0.3",
+                "yauzl": "^2.2.1",
+                "yazl": "^2.2.1"
             },
             "dependencies": {
                 "clone": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.1.tgz",
-                    "integrity": "sha1-0hfR6WERjjrJpLi7oyhVU79kfNs=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
                 "clone-stats": {
@@ -1404,38 +1372,20 @@
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
-                "queue": {
-                    "version": "4.4.2",
-                    "resolved": "https://registry.npmjs.org/queue/-/queue-4.4.2.tgz",
-                    "integrity": "sha512-fSMRXbwhMwipcDZ08enW2vl+YDmAmhcNcr43sCJL8DIg+CFOsoRLG23ctxA+fwNk1w55SePSiS7oqQQSgQoVJQ==",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
                 "vinyl": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.1.0.tgz",
-                    "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.1",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
-            }
-        },
-        "gulplog": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
-            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
-            "dev": true,
-            "requires": {
-                "glogg": "1.0.1"
             }
         },
         "har-schema": {
@@ -1445,15 +1395,22 @@
             "dev": true
         },
         "har-validator": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-            "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.13.0",
-                "is-my-json-valid": "2.17.2",
-                "pinkie-promise": "2.0.1"
+                "ajv": "^6.5.5",
+                "har-schema": "^2.0.0"
+            }
+        },
+        "has": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+            "dev": true,
+            "requires": {
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -1462,7 +1419,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-flag": {
@@ -1471,49 +1428,40 @@
             "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
             "dev": true
         },
-        "has-gulplog": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
-            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
-            "dev": true,
-            "requires": {
-                "sparkles": "1.0.0"
-            }
-        },
-        "hawk": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-            "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-            "dev": true,
-            "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
-            }
+        "has-symbols": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+            "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+            "dev": true
         },
         "he": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
-            "dev": true
-        },
-        "hoek": {
-            "version": "2.16.3",
-            "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-            "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-            "dev": true
+            "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
         },
         "http-signature": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-            "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+            "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.1"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
+        },
+        "iconv-lite": {
+            "version": "0.4.24",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+            "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+            "requires": {
+                "safer-buffer": ">= 2.1.2 < 3"
+            }
+        },
+        "ignore": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
         },
         "import-lazy": {
             "version": "2.1.0",
@@ -1529,28 +1477,107 @@
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-            "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-            "dev": true
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
             "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
+        "inquirer": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.1.tgz",
+            "integrity": "sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==",
+            "requires": {
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.17.10",
+                "mute-stream": "0.0.7",
+                "run-async": "^2.2.0",
+                "rxjs": "^6.1.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^5.0.0",
+                "through": "^2.3.6"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
+                    "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+                },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.1",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+                    "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+                },
+                "strip-ansi": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
+                    "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+                    "requires": {
+                        "ansi-regex": "^4.0.0"
+                    }
+                },
+                "supports-color": {
+                    "version": "5.5.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                }
+            }
+        },
         "is": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
             "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
             "dev": true
+        },
+        "is-absolute": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
+            "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
+            "dev": true,
+            "requires": {
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
+            }
         },
         "is-buffer": {
             "version": "1.1.6",
@@ -1563,29 +1590,8 @@
             "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
             "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
             "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.0.0"
             }
-        },
-        "is-dotfile": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-            "dev": true
-        },
-        "is-equal-shallow": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
-            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-            "dev": true,
-            "requires": {
-                "is-primitive": "2.0.0"
-            }
-        },
-        "is-extendable": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -1604,7 +1610,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-installed-globally": {
@@ -1612,53 +1618,20 @@
             "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
             "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
             "requires": {
-                "global-dirs": "0.1.1",
-                "is-path-inside": "1.0.1"
+                "global-dirs": "^0.1.0",
+                "is-path-inside": "^1.0.0"
             }
         },
-        "is-my-ip-valid": {
+        "is-negated-glob": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-my-ip-valid/-/is-my-ip-valid-1.0.0.tgz",
-            "integrity": "sha512-gmh/eWXROncUzRnIa1Ubrt5b8ep/MGSnfAUI3aRp+sqTCs1tv1Isl8d8F6JmkN3dXKc3ehZMrtiPN9eL03NuaQ==",
+            "resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
+            "integrity": "sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=",
             "dev": true
-        },
-        "is-my-json-valid": {
-            "version": "2.17.2",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-            "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
-            "dev": true,
-            "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
-            }
         },
         "is-npm": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-npm/-/is-npm-1.0.0.tgz",
             "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
-        },
-        "is-number": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
-            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-            "dev": true,
-            "requires": {
-                "kind-of": "3.2.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
-            }
         },
         "is-obj": {
             "version": "1.0.1",
@@ -1670,31 +1643,27 @@
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
-        "is-posix-bracket": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-            "dev": true
-        },
-        "is-primitive": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
-            "dev": true
-        },
-        "is-property": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
-            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
-            "dev": true
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
         },
         "is-redirect": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
             "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+        },
+        "is-relative": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-1.0.0.tgz",
+            "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
+            "dev": true,
+            "requires": {
+                "is-unc-path": "^1.0.0"
+            }
         },
         "is-retry-allowed": {
             "version": "1.1.0",
@@ -1712,6 +1681,15 @@
             "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
             "dev": true
         },
+        "is-unc-path": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
+            "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
+            "dev": true,
+            "requires": {
+                "unc-path-regex": "^0.1.2"
+            }
+        },
         "is-utf8": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
@@ -1719,9 +1697,15 @@
             "dev": true
         },
         "is-valid-glob": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-0.3.0.tgz",
-            "integrity": "sha1-1LVcafUYhvm2XHDWwmItN+KfSP4=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-valid-glob/-/is-valid-glob-1.0.0.tgz",
+            "integrity": "sha1-Kb8+/3Ab4tTTFdusw5vDn+j2Aao=",
+            "dev": true
+        },
+        "is-windows": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
             "dev": true
         },
         "isarray": {
@@ -1734,15 +1718,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
-        },
-        "isobject": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-            "dev": true,
-            "requires": {
-                "isarray": "1.0.0"
-            }
         },
         "isstream": {
             "version": "0.1.2",
@@ -1762,16 +1737,15 @@
             "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.9",
-                "esprima": "4.0.0"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "json-schema": {
             "version": "0.2.3",
@@ -1780,9 +1754,9 @@
             "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true
         },
         "json-stable-stringify": {
@@ -1791,8 +1765,13 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -1806,12 +1785,6 @@
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
             "dev": true
         },
-        "jsonpointer": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
-            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
-            "dev": true
-        },
         "jsprim": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -1822,14 +1795,6 @@
                 "extsprintf": "1.3.0",
                 "json-schema": "0.2.3",
                 "verror": "1.10.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
             }
         },
         "kind-of": {
@@ -1843,7 +1808,7 @@
             "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
             "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
             "requires": {
-                "package-json": "4.0.1"
+                "package-json": "^4.0.0"
             }
         },
         "lazystream": {
@@ -1852,138 +1817,31 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
+            }
+        },
+        "lead": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lead/-/lead-1.0.0.tgz",
+            "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
+            "dev": true,
+            "requires": {
+                "flush-write-stream": "^1.0.2"
+            }
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "requires": {
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "lodash": {
             "version": "3.10.1",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
             "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
-        },
-        "lodash._basecopy": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
-            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
-            "dev": true
-        },
-        "lodash._basetostring": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
-            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
-            "dev": true
-        },
-        "lodash._basevalues": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
-            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
-            "dev": true
-        },
-        "lodash._getnative": {
-            "version": "3.9.1",
-            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
-            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
-            "dev": true
-        },
-        "lodash._isiterateecall": {
-            "version": "3.0.9",
-            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
-            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
-            "dev": true
-        },
-        "lodash._reescape": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
-            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
-            "dev": true
-        },
-        "lodash._reevaluate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
-            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
-            "dev": true
-        },
-        "lodash._reinterpolate": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
-            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
-            "dev": true
-        },
-        "lodash._root": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
-            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
-            "dev": true
-        },
-        "lodash.escape": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
-            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
-            "dev": true,
-            "requires": {
-                "lodash._root": "3.0.1"
-            }
-        },
-        "lodash.isarguments": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
-            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
-            "dev": true
-        },
-        "lodash.isarray": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
-            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
-            "dev": true
-        },
-        "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-            "dev": true
-        },
-        "lodash.keys": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
-            "dev": true,
-            "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
-            }
-        },
-        "lodash.restparam": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
-            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
-            "dev": true
-        },
-        "lodash.template": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
-            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
-            "dev": true,
-            "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
-            }
-        },
-        "lodash.templatesettings": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
-            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
-            "dev": true,
-            "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
-            }
         },
         "lowercase-keys": {
             "version": "1.0.1",
@@ -1995,8 +1853,8 @@
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
             "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "make-dir": {
@@ -2004,7 +1862,7 @@
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
             "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "map-stream": {
@@ -2013,106 +1871,43 @@
             "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
             "dev": true
         },
-        "merge-stream": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-1.0.1.tgz",
-            "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
-            "dev": true,
-            "requires": {
-                "readable-stream": "2.3.3"
-            }
-        },
-        "micromatch": {
-            "version": "2.3.11",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-            "dev": true,
-            "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
-            },
-            "dependencies": {
-                "arr-diff": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                    "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-                    "dev": true,
-                    "requires": {
-                        "arr-flatten": "1.1.0"
-                    }
-                },
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
-            }
-        },
         "mime-db": {
-            "version": "1.33.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "version": "1.37.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
+            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.18",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-            "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+            "version": "2.1.21",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
+            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
             "dev": true,
             "requires": {
-                "mime-db": "1.33.0"
+                "mime-db": "~1.37.0"
             }
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         },
         "minimatch": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-            "dev": true,
             "requires": {
-                "brace-expansion": "1.1.8"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
             "version": "0.0.8",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-            "dev": true
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mkdirp": {
             "version": "0.5.1",
             "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-            "dev": true,
             "requires": {
                 "minimist": "0.0.8"
             }
@@ -2147,7 +1942,7 @@
                     "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -2164,20 +1959,26 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             }
         },
-        "multipipe": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
-            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
-            "dev": true,
-            "requires": {
-                "duplexer2": "0.0.2"
-            }
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
+        },
+        "nice-try": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-fs": {
             "version": "0.1.7",
@@ -2185,12 +1986,13 @@
             "integrity": "sha1-MjI8zLRsn78PwRgS1FAhzDHTJbs="
         },
         "node.extend": {
-            "version": "1.1.6",
-            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
-            "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.8.tgz",
+            "integrity": "sha512-L/dvEBwyg3UowwqOUTyDsGBU6kjBQOpOhshio9V3i3BMPv5YUb9+mWNN8MK0IbWqT0AqaTSONZf0aTuMMahWgA==",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "has": "^1.0.3",
+                "is": "^3.2.1"
             }
         },
         "normalize-path": {
@@ -2199,7 +2001,16 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
+            }
+        },
+        "now-and-later": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/now-and-later/-/now-and-later-2.0.0.tgz",
+            "integrity": "sha1-vGHLtFbXnLMiB85HygUTb/Ln1u4=",
+            "dev": true,
+            "requires": {
+                "once": "^1.3.2"
             }
         },
         "npm-run-path": {
@@ -2207,49 +2018,80 @@
             "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+        },
+        "object-keys": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+            "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
             "dev": true
         },
-        "object.omit": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+        "object.assign": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+            "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-            "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "requires": {
+                "mimic-fn": "^1.0.0"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "requires": {
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             }
         },
         "ordered-read-streams": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-0.3.0.tgz",
-            "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
+            "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.1"
             }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "p-finally": {
             "version": "1.0.0",
@@ -2261,39 +2103,10 @@
             "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
             "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
             "requires": {
-                "got": "6.7.1",
-                "registry-auth-token": "3.3.2",
-                "registry-url": "3.1.0",
-                "semver": "5.5.0"
-            }
-        },
-        "parse-glob": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-            "dev": true,
-            "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
-            },
-            "dependencies": {
-                "is-extglob": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-                    "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-                    "dev": true
-                },
-                "is-glob": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                    "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-                    "dev": true,
-                    "requires": {
-                        "is-extglob": "1.0.0"
-                    }
-                }
+                "got": "^6.7.1",
+                "registry-auth-token": "^3.0.1",
+                "registry-url": "^3.0.3",
+                "semver": "^5.1.0"
             }
         },
         "path-dirname": {
@@ -2305,8 +2118,7 @@
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-            "dev": true
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
             "version": "1.0.2",
@@ -2330,7 +2142,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -2350,55 +2162,76 @@
             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
-        "pinkie": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
-        },
-        "pinkie-promise": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
-            "requires": {
-                "pinkie": "2.0.4"
-            }
-        },
         "plugin-error": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/plugin-error/-/plugin-error-0.1.2.tgz",
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             }
+        },
+        "pluralize": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow=="
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
         },
         "prepend-http": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
             "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
-        "preserve": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
             "dev": true
         },
-        "process-nextick-args": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-            "dev": true
+        "progress": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
         },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
             "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+        },
+        "psl": {
+            "version": "1.1.31",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
+            "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+            "dev": true
+        },
+        "pump": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+            "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+            "dev": true,
+            "requires": {
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
+            }
+        },
+        "pumpify": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+            "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
+            "dev": true,
+            "requires": {
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
+            }
         },
         "punycode": {
             "version": "1.4.1",
@@ -2412,65 +2245,24 @@
             "integrity": "sha1-EYcq7t7okmgRCxCnGESP+xARKhQ="
         },
         "qs": {
-            "version": "6.3.2",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.2.tgz",
-            "integrity": "sha1-51vV9uJoEioqDgvaYwslUMFmUCw=",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+            "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
             "dev": true
         },
         "querystringify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.0.0.tgz",
-            "integrity": "sha512-eTPo5t/4bgaMNZxyjWx6N2a6AuE0mq51KWvpc7nU/MAqixcI6v6KrGUKES0HaomdnolQBBXU/++X6/QQ9KL4tw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
+            "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
             "dev": true
         },
         "queue": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/queue/-/queue-3.1.0.tgz",
-            "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/queue/-/queue-4.5.1.tgz",
+            "integrity": "sha512-AMD7w5hRXcFSb8s9u38acBZ+309u6GsiibP4/0YacJeaurRshogB7v/ZcVPxP5gD5+zIw6ixRHdutiYUJfwKHw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
-            }
-        },
-        "randomatic": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
-            "dev": true,
-            "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
-            },
-            "dependencies": {
-                "is-number": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-                    "dev": true,
-                    "requires": {
-                        "kind-of": "3.2.2"
-                    },
-                    "dependencies": {
-                        "kind-of": {
-                            "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                            "dev": true,
-                            "requires": {
-                                "is-buffer": "1.1.6"
-                            }
-                        }
-                    }
-                },
-                "kind-of": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
-                    "requires": {
-                        "is-buffer": "1.1.6"
-                    }
-                }
+                "inherits": "~2.0.0"
             }
         },
         "rc": {
@@ -2478,10 +2270,10 @@
             "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
             "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
             "requires": {
-                "deep-extend": "0.5.1",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.5.1",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             },
             "dependencies": {
                 "minimist": {
@@ -2492,36 +2284,32 @@
             }
         },
         "readable-stream": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-            "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+            "version": "2.3.6",
+            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
-        "regex-cache": {
-            "version": "0.4.4",
-            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-            "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-            "dev": true,
-            "requires": {
-                "is-equal-shallow": "0.1.3"
-            }
+        "regexpp": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+            "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
         },
         "registry-auth-token": {
             "version": "3.3.2",
             "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
             "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
             "requires": {
-                "rc": "1.2.7",
-                "safe-buffer": "5.1.1"
+                "rc": "^1.1.6",
+                "safe-buffer": "^5.0.1"
             }
         },
         "registry-url": {
@@ -2529,25 +2317,34 @@
             "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
             "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
             "requires": {
-                "rc": "1.2.7"
+                "rc": "^1.0.1"
+            }
+        },
+        "remove-bom-buffer": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-buffer/-/remove-bom-buffer-3.0.0.tgz",
+            "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
+            "dev": true,
+            "requires": {
+                "is-buffer": "^1.1.5",
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "remove-bom-stream": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/remove-bom-stream/-/remove-bom-stream-1.2.0.tgz",
+            "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
+            "dev": true,
+            "requires": {
+                "remove-bom-buffer": "^3.0.0",
+                "safe-buffer": "^5.1.0",
+                "through2": "^2.0.3"
             }
         },
         "remove-trailing-separator": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
             "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-            "dev": true
-        },
-        "repeat-element": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
-            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-            "dev": true
-        },
-        "repeat-string": {
-            "version": "1.6.1",
-            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
         },
         "replace-ext": {
@@ -2557,156 +2354,48 @@
             "dev": true
         },
         "request": {
-            "version": "2.85.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-            "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.7.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.1",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "hawk": "6.0.2",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.18",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.1",
-                "safe-buffer": "5.1.1",
-                "stringstream": "0.0.5",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.2.1"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
             },
             "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+                "safe-buffer": {
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+                    "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
                     "dev": true
-                },
-                "aws-sign2": {
-                    "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-                    "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-                    "dev": true
-                },
-                "boom": {
-                    "version": "4.3.1",
-                    "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-                    "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "4.2.1"
-                    }
-                },
-                "caseless": {
-                    "version": "0.12.0",
-                    "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-                    "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-                    "dev": true
-                },
-                "cryptiles": {
-                    "version": "3.1.2",
-                    "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-                    "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
-                    "dev": true,
-                    "requires": {
-                        "boom": "5.2.0"
-                    },
-                    "dependencies": {
-                        "boom": {
-                            "version": "5.2.0",
-                            "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-                            "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-                            "dev": true,
-                            "requires": {
-                                "hoek": "4.2.1"
-                            }
-                        }
-                    }
-                },
-                "form-data": {
-                    "version": "2.3.2",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
-                    "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
-                    "dev": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.6",
-                        "mime-types": "2.1.18"
-                    }
-                },
-                "har-validator": {
-                    "version": "5.0.3",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "5.5.2",
-                        "har-schema": "2.0.0"
-                    }
-                },
-                "hawk": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-                    "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
-                    "dev": true,
-                    "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.1",
-                        "sntp": "2.1.0"
-                    }
-                },
-                "hoek": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-                    "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
-                    "dev": true
-                },
-                "http-signature": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-                    "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-                    "dev": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.1"
-                    }
-                },
-                "qs": {
-                    "version": "6.5.1",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-                    "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-                    "dev": true
-                },
-                "sntp": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-                    "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
-                    "dev": true,
-                    "requires": {
-                        "hoek": "4.2.1"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-                    "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "5.1.1"
-                    }
                 }
+            }
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "requires": {
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             }
         },
         "requires-port": {
@@ -2721,22 +2410,65 @@
             "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
+            }
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY="
+        },
+        "resolve-options": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
+            "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
+            "dev": true,
+            "requires": {
+                "value-or-function": "^3.0.0"
+            }
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "requires": {
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "rimraf": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-            "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "requires": {
+                "is-promise": "^2.1.0"
+            }
+        },
+        "rxjs": {
+            "version": "6.3.3",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+            "requires": {
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
             "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
             "version": "5.5.0",
@@ -2748,7 +2480,7 @@
             "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
             "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.0.3"
             }
         },
         "shebang-command": {
@@ -2756,7 +2488,7 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -2769,13 +2501,24 @@
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
-        "sntp": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-            "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-            "dev": true,
+        "slice-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.0.0.tgz",
+            "integrity": "sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==",
             "requires": {
-                "hoek": "2.16.3"
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                }
             }
         },
         "source-map": {
@@ -2785,20 +2528,14 @@
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.5.tgz",
-            "integrity": "sha512-mR7/Nd5l1z6g99010shcXJiNEaf3fEtmLhRB/sBcQVJGodcHCULPp2y4Sfa43Kv2zq7T+Izmfp/WHCR6dYkQCA==",
+            "version": "0.5.9",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
+            "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.0.0",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
-        },
-        "sparkles": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
-            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
-            "dev": true
         },
         "split": {
             "version": "0.3.3",
@@ -2806,37 +2543,29 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sprintf-js": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-            "dev": true
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
         },
         "sshpk": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-            "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
+            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "stat-mode": {
@@ -2851,7 +2580,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-shift": {
@@ -2866,7 +2595,7 @@
             "integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -2880,8 +2609,8 @@
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -2894,25 +2623,19 @@
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
         },
         "string_decoder": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "version": "1.1.1",
+            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
-        },
-        "stringstream": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-            "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-            "dev": true
         },
         "strip-ansi": {
             "version": "3.0.1",
@@ -2920,26 +2643,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
-            }
-        },
-        "strip-bom": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-            "dev": true,
-            "requires": {
-                "is-utf8": "0.2.1"
-            }
-        },
-        "strip-bom-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-1.0.0.tgz",
-            "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
-            "dev": true,
-            "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-eof": {
@@ -2958,15 +2662,54 @@
             "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
             "dev": true
         },
+        "table": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.1.1.tgz",
+            "integrity": "sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==",
+            "requires": {
+                "ajv": "^6.6.1",
+                "lodash": "^4.17.11",
+                "slice-ansi": "2.0.0",
+                "string-width": "^2.1.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.6.1",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
+                    "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "fast-deep-equal": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+                    "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+                },
+                "lodash": {
+                    "version": "4.17.11",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+                    "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+                }
+            }
+        },
         "tar": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "term-size": {
@@ -2974,23 +2717,27 @@
             "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
             }
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
         },
         "through": {
             "version": "2.3.8",
             "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-            "dev": true
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "readable-stream": "~2.3.6",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -2999,55 +2746,56 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
-        },
-        "time-stamp": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
-            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
-            "dev": true
         },
         "timed-out": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "requires": {
+                "os-tmpdir": "~1.0.2"
+            }
+        },
         "to-absolute-glob": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-0.1.1.tgz",
-            "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/to-absolute-glob/-/to-absolute-glob-2.0.2.tgz",
+            "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "0.1.1"
-                    }
-                }
+                "is-absolute": "^1.0.0",
+                "is-negated-glob": "^1.0.0"
+            }
+        },
+        "to-through": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-through/-/to-through-2.0.0.tgz",
+            "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
+            "dev": true,
+            "requires": {
+                "through2": "^2.0.3"
             }
         },
         "tough-cookie": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-            "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+            "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             }
         },
         "tslib": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-            "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
-            "dev": true
+            "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
         },
         "tslint": {
             "version": "5.9.1",
@@ -3055,18 +2803,18 @@
             "integrity": "sha1-ElX4ej/1frCw4fDmEKi0dIBGya4=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.3.0",
-                "commander": "2.13.0",
-                "diff": "3.3.1",
-                "glob": "7.1.2",
-                "js-yaml": "3.10.0",
-                "minimatch": "3.0.4",
-                "resolve": "1.5.0",
-                "semver": "5.5.0",
-                "tslib": "1.9.0",
-                "tsutils": "2.19.1"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.12.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3075,7 +2823,7 @@
                     "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
                     "dev": true,
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -3084,9 +2832,9 @@
                     "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.0",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "4.5.0"
+                        "ansi-styles": "^3.1.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^4.0.0"
                     }
                 },
                 "supports-color": {
@@ -3095,7 +2843,7 @@
                     "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "2.0.0"
+                        "has-flag": "^2.0.0"
                     }
                 }
             }
@@ -3106,26 +2854,42 @@
             "integrity": "sha512-1B3z4H4HddgzWptqLzwrJloDEsyBt8DvZhnFO14k7A4RsQL/UhEfQjD4hpcY5NpF3veBkjJhQJ8Bl7Xp96cN+A==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.0"
+                "tslib": "^1.8.1"
             }
         },
         "tunnel-agent": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
-            "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us=",
-            "dev": true
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
         },
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-            "dev": true,
-            "optional": true
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "requires": {
+                "prelude-ls": "~1.1.2"
+            }
         },
         "typescript": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
             "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+            "dev": true
+        },
+        "unc-path-regex": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
+            "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
             "dev": true
         },
         "unique-stream": {
@@ -3134,8 +2898,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "unique-string": {
@@ -3143,7 +2907,7 @@
             "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
             "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
             "requires": {
-                "crypto-random-string": "1.0.0"
+                "crypto-random-string": "^1.0.0"
             }
         },
         "unzip-response": {
@@ -3156,16 +2920,16 @@
             "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
             "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
             "requires": {
-                "boxen": "1.3.0",
-                "chalk": "2.4.1",
-                "configstore": "3.1.2",
-                "import-lazy": "2.1.0",
-                "is-ci": "1.1.0",
-                "is-installed-globally": "0.1.0",
-                "is-npm": "1.0.0",
-                "latest-version": "3.1.0",
-                "semver-diff": "2.1.0",
-                "xdg-basedir": "3.0.0"
+                "boxen": "^1.2.1",
+                "chalk": "^2.0.1",
+                "configstore": "^3.0.0",
+                "import-lazy": "^2.1.0",
+                "is-ci": "^1.0.10",
+                "is-installed-globally": "^0.1.0",
+                "is-npm": "^1.0.0",
+                "latest-version": "^3.0.0",
+                "semver-diff": "^2.0.0",
+                "xdg-basedir": "^3.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -3173,7 +2937,7 @@
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
                     "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
                     "requires": {
-                        "color-convert": "1.9.1"
+                        "color-convert": "^1.9.0"
                     }
                 },
                 "chalk": {
@@ -3181,9 +2945,9 @@
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
                     "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
                     }
                 },
                 "has-flag": {
@@ -3196,19 +2960,34 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
                     "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
                     "requires": {
-                        "has-flag": "3.0.0"
+                        "has-flag": "^3.0.0"
                     }
                 }
             }
         },
+        "uri-js": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "requires": {
+                "punycode": "^2.1.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+                    "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+                }
+            }
+        },
         "url-parse": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.0.tgz",
-            "integrity": "sha512-ERuGxDiQ6Xw/agN4tuoCRbmwRuZP0cJ1lJxJubXr5Q/5cDa78+Dc4wfvtxzhzhkm5VvmW6Mf8EVj9SPGN4l8Lg==",
+            "version": "1.4.4",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+            "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
             "dev": true,
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "url-parse-lax": {
@@ -3216,7 +2995,7 @@
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
             "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
             "requires": {
-                "prepend-http": "1.0.4"
+                "prepend-http": "^1.0.1"
             }
         },
         "util-deprecate": {
@@ -3226,15 +3005,15 @@
             "dev": true
         },
         "uuid": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-            "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
             "dev": true
         },
-        "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+        "value-or-function": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/value-or-function/-/value-or-function-3.0.0.tgz",
+            "integrity": "sha1-HCQ6ULWVwb5Up1S/7OhWO5/42BM=",
             "dev": true
         },
         "verror": {
@@ -3243,17 +3022,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
-            },
-            "dependencies": {
-                "assert-plus": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-                    "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-                    "dev": true
-                }
+                "extsprintf": "^1.2.0"
             }
         },
         "vinyl": {
@@ -3262,56 +3033,59 @@
             "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
             "dev": true,
             "requires": {
-                "clone": "0.2.0",
-                "clone-stats": "0.0.1"
+                "clone": "^0.2.0",
+                "clone-stats": "^0.0.1"
             }
         },
         "vinyl-fs": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-2.4.4.tgz",
-            "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/vinyl-fs/-/vinyl-fs-3.0.3.tgz",
+            "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.3",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
-                "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.3",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "fs-mkdirp-stream": "^1.0.0",
+                "glob-stream": "^6.1.0",
+                "graceful-fs": "^4.0.0",
+                "is-valid-glob": "^1.0.0",
+                "lazystream": "^1.0.0",
+                "lead": "^1.0.0",
+                "object.assign": "^4.0.4",
+                "pumpify": "^1.3.5",
+                "readable-stream": "^2.3.3",
+                "remove-bom-buffer": "^3.0.0",
+                "remove-bom-stream": "^1.2.0",
+                "resolve-options": "^1.1.0",
+                "through2": "^2.0.0",
+                "to-through": "^2.0.0",
+                "value-or-function": "^3.0.0",
+                "vinyl": "^2.0.0",
+                "vinyl-sourcemap": "^1.1.0"
             },
             "dependencies": {
                 "clone": {
-                    "version": "1.0.4",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-                    "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
                     "dev": true
                 },
-                "replace-ext": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
-                    "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
                 },
                 "vinyl": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-1.2.0.tgz",
-                    "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.4",
-                        "clone-stats": "0.0.1",
-                        "replace-ext": "0.0.1"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -3322,30 +3096,73 @@
             "integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "vinyl": "0.4.6"
+                "through2": "^2.0.3",
+                "vinyl": "^0.4.3"
+            }
+        },
+        "vinyl-sourcemap": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/vinyl-sourcemap/-/vinyl-sourcemap-1.1.0.tgz",
+            "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
+            "dev": true,
+            "requires": {
+                "append-buffer": "^1.0.2",
+                "convert-source-map": "^1.5.0",
+                "graceful-fs": "^4.1.6",
+                "normalize-path": "^2.1.1",
+                "now-and-later": "^2.0.0",
+                "remove-bom-buffer": "^3.0.0",
+                "vinyl": "^2.0.0"
+            },
+            "dependencies": {
+                "clone": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+                    "dev": true
+                },
+                "clone-stats": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+                    "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+                    "dev": true
+                },
+                "vinyl": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
+                    "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+                    "dev": true,
+                    "requires": {
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
+                    }
+                }
             }
         },
         "vscode": {
-            "version": "1.1.16",
-            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.16.tgz",
-            "integrity": "sha512-nNsfYANLqqNfa2+flHyrIrqSIumIoV7R+R9H3gn0SAzZL3RGPEy8db3EYjXKPW5NEfssj/HZhSMI3J3pMNmhPA==",
+            "version": "1.1.26",
+            "resolved": "https://registry.npmjs.org/vscode/-/vscode-1.1.26.tgz",
+            "integrity": "sha512-z1Nf5J38gjUFbuDCbJHPN6OJ//5EG+e/yHlh6ERxj/U9B2Qc3aiHaFr38/fee/GGnxvRw/XegLMOG+UJwKi/Qg==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.1.0",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.1.0",
-                "request": "2.85.0",
-                "semver": "5.5.0",
-                "source-map-support": "0.5.5",
-                "url-parse": "1.4.0",
-                "vinyl-source-stream": "1.1.2"
+                "gulp-remote-src-vscode": "^0.5.1",
+                "gulp-untar": "^0.0.7",
+                "gulp-vinyl-zip": "^2.1.2",
+                "mocha": "^4.0.1",
+                "request": "^2.88.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.4.3",
+                "vinyl-fs": "^3.0.3",
+                "vinyl-source-stream": "^1.1.0"
             }
         },
         "when": {
@@ -3358,7 +3175,7 @@
             "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
             "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "widest-line": {
@@ -3366,23 +3183,35 @@
             "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
             "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
             "requires": {
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             }
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         },
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-            "dev": true
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "requires": {
+                "mkdirp": "^0.5.1"
+            }
         },
         "write-file-atomic": {
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
             "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
             "requires": {
-                "graceful-fs": "4.1.11",
-                "imurmurhash": "0.1.4",
-                "signal-exit": "3.0.2"
+                "graceful-fs": "^4.1.11",
+                "imurmurhash": "^0.1.4",
+                "signal-exit": "^3.0.2"
             }
         },
         "xdg-basedir": {
@@ -3405,12 +3234,12 @@
             "resolved": "https://registry.npmjs.org/xqlint/-/xqlint-0.4.1.tgz",
             "integrity": "sha1-2Tvnrui6JGmCyDobmZlscjQEW/k=",
             "requires": {
-                "colors": "0.6.2",
-                "commander": "2.3.0",
-                "final-fs": "1.6.1",
-                "lodash": "3.10.1",
-                "q": "1.0.1",
-                "update-notifier": "2.5.0"
+                "colors": "~0.6.2",
+                "commander": "~2.3.0",
+                "final-fs": "~1.6.0",
+                "lodash": "^3.2.0",
+                "q": "~1.0.0",
+                "update-notifier": "~2.5.0"
             },
             "dependencies": {
                 "commander": {
@@ -3418,6 +3247,15 @@
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
                     "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM="
                 }
+            }
+        },
+        "xslt-processor": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/xslt-processor/-/xslt-processor-0.11.1.tgz",
+            "integrity": "sha512-2AmXWzFYHTUxIam+PVkhpqQMvxJy4Y9uR7Tmk4KOPKNPPV2j/NTBmn09r/LzIMKKTNfou5TrrMeJ1CMBbXIFfg==",
+            "requires": {
+                "eslint": "^5.8.0",
+                "he": "^1.1.1"
             }
         },
         "xtend": {
@@ -3432,22 +3270,22 @@
             "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yauzl": {
-            "version": "2.9.1",
-            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-            "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+            "version": "2.10.0",
+            "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+            "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.1.0"
             }
         },
         "yazl": {
-            "version": "2.4.3",
-            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.4.3.tgz",
-            "integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/yazl/-/yazl-2.5.1.tgz",
+            "integrity": "sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "url": "https://github.com/DotJoshJohnson/vscode-xml/issues"
     },
     "engines": {
-        "vscode": "^1.22.2"
+        "vscode": "^1.29.0"
     },
     "categories": [
         "Formatters",
@@ -36,6 +36,7 @@
         "onCommand:xmlTools.executeXQuery",
         "onCommand:xmlTools.formatAsXml",
         "onCommand:xmlTools.minifyXml",
+        "onCommand:xmlTools.runXSLTTransform",
         "onLanguage:xml",
         "onLanguage:xquery",
         "onLanguage:xsl"
@@ -62,6 +63,10 @@
             {
                 "command": "xmlTools.minifyXml",
                 "title": "XML Tools: Minify XML"
+            },
+            {
+                "command": "xmlTools.runXSLTTransform",
+                "title": "XML Tools: Run XSLT Transformation"
             }
         ],
         "configuration": {
@@ -250,11 +255,12 @@
         "@types/xmldom": "^0.1.29",
         "tslint": "^5.9.1",
         "typescript": "^2.6.1",
-        "vscode": "^1.1.16"
+        "vscode": "^1.1.26"
     },
     "dependencies": {
         "xmldom": "^0.1.27",
         "xpath": "0.0.27",
-        "xqlint": "^0.4.1"
+        "xqlint": "^0.4.1",
+        "xslt-processor": "^0.11.1"
     }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@ export namespace commands {
     export const formatAsXml = "xmlTools.formatAsXml";
     export const getCurrentXPath = "xmlTools.getCurrentXPath";
     export const minifyXml = "xmlTools.minifyXml";
+    export const runXSLTTransform = "xmlTools.runXSLTTransform";
 }
 
 export namespace contextKeys {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,7 @@ import { XQueryLinter } from "./linting";
 import { XmlTreeDataProvider } from "./tree-view";
 import { evaluateXPath, getCurrentXPath } from "./xpath/commands";
 import { executeXQuery } from "./xquery-execution/commands";
+import { runXSLTTransform } from "./xslt";
 
 import * as constants from "./constants";
 
@@ -48,7 +49,7 @@ export function activate(context: ExtensionContext) {
     });
 
     if (Configuration.enableXmlTreeViewCursorSync) {
-        window.onDidChangeTextEditorSelection(x => {
+        window.onDidChangeTextEditorSelection((x: any) => {
             if (x.kind === TextEditorSelectionChangeKind.Mouse && x.selections.length > 0) {
                 treeView.reveal(treeViewDataProvider.getNodeAtPosition(x.selections[0].start));
             }
@@ -68,6 +69,11 @@ export function activate(context: ExtensionContext) {
     /* XQuery Features */
     context.subscriptions.push(
         commands.registerTextEditorCommand(constants.commands.executeXQuery, executeXQuery)
+    );
+
+    /* XSLT Transformation Features */
+    context.subscriptions.push(
+        commands.registerCommand(constants.commands.runXSLTTransform, runXSLTTransform)
     );
 }
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,10 +1,11 @@
 import * as assert from "assert";
-import { FormattingOptions } from "vscode";
 
 import { TestDataLoader } from "./test-utils/test-data-loader";
 
 import { XmlFormatter, XmlFormattingOptions } from "../formatting";
 import { V2XmlFormatter } from "../formatting/formatters";
+import { readFileSync } from "fs";
+import { XSLTTransform } from "../xslt/xslt-transform";
 
 describe("V2XmlFormatter", () => {
 
@@ -90,6 +91,13 @@ describe("V2XmlFormatter", () => {
 
         it("should support mixed content", () => {
             testFormatter(xmlFormatter, options, "issue-200");
+        });
+        it("show transform XML to XSLT", () => {
+            assert.doesNotThrow(() => {
+                const xml = TestDataLoader.load("xslt-transform.xml");
+                const xslt = TestDataLoader.load("xslt-transform.xsl");
+                new XSLTTransform(xml, xslt).apply();
+            });
         });
 
     });

--- a/src/test/test-data/xslt-transform.xml
+++ b/src/test/test-data/xslt-transform.xml
@@ -1,0 +1,48 @@
+<schedule>
+    <week>
+        <weektext>Orientation Week 1</weektext>
+        <start_date>2018-07-30</start_date>
+        <end_date>2018-08-11</end_date>
+        <events>
+            <event>
+                <event_id>2317</event_id>
+                <day>Sunday</day>
+                <start_date_time>2018-08-06T07:30:00</start_date_time>
+                <end_date_time>2018-08-06T12:00:00</end_date_time>
+                <length>270</length>
+                <event_title>Training</event_title>
+                <short_name>Training</short_name>
+                <instances>
+                    <instance>
+                        <start_date_time>2018-08-06T07:30:00</start_date_time>
+                        <end_date_time>2018-08-06T12:00:00</end_date_time>
+                        <room>See Course Website</room>
+                        <instructors>
+                            <instructor>... TBA</instructor>
+                        </instructors>
+                    </instance>
+                </instances>
+            </event>
+            <event>
+                <event_id>2316</event_id>
+                <day>Sunday</day>
+                <start_date_time>2018-08-06T08:10:00</start_date_time>
+                <end_date_time>2018-08-06T12:00:00</end_date_time>
+                <length>230</length>
+                <event_title>Challenge Course</event_title>
+                <short_name>Challenge</short_name>
+                <instances>
+                    <instance>
+                        <start_date_time>2018-08-06T08:10:00</start_date_time>
+                        <end_date_time>2018-08-06T12:00:00</end_date_time>
+                        <room>See Course Website</room>
+                        <instructors>
+                            <instructor>Person One</instructor>
+                            <instructor>Person Two</instructor>
+                        </instructors>
+                    </instance>
+                </instances>
+            </event>
+        </events>
+    </week>
+</schedule>

--- a/src/test/test-data/xslt-transform.xsl
+++ b/src/test/test-data/xslt-transform.xsl
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="xs" version="2.0">
+    <xsl:template match="/">
+
+        <div>
+            
+            <table>
+                            
+            <xsl:for-each select="/schedule/week">
+                <xsl:sort select="weektext"/>
+                <tr><td colspan="4"><xsl:value-of select="weektext"/></td></tr>
+                <xsl:for-each select="events/event">
+                    <xsl:sort select="events/event/start_date_time" type="datetime"/>
+                      <tr>
+                            <td>
+                                <xsl:value-of select="FormattedDate"/>
+                            </td>
+                            <td>
+                                <xsl:value-of select="event_title"/>
+                            </td>
+                            <td>
+                                <xsl:value-of select="length"/> minutes 
+                            </td>
+                          <td>
+                              <a href="Activity?EventID={event_id}">details...</a>
+                          </td>
+                        </tr>
+                        <tr>
+                            <td colspan="4">
+                                <table>
+                                    <xsl:for-each select="instances/instance">
+                                        <tr>
+                                            <td>
+                                                <xsl:value-of select="start_date_time_formatted"/>
+                                            </td>
+                                            <td>
+                                                <xsl:value-of select="end_date_time_formatted"/>
+                                            </td>
+                                            <td>
+                                                <xsl:value-of select="room"/>
+                                            </td>
+                                            <td>
+                                                <xsl:apply-templates select="instructors/instructor"
+                                                />
+                                            </td>
+                                        </tr>
+                                    </xsl:for-each>
+                                </table>
+                            </td>
+                        
+                        </tr>
+                    
+                </xsl:for-each>
+
+            </xsl:for-each>
+
+            </table>
+
+        </div>
+    </xsl:template>
+
+    <xsl:template match="instructor">
+        <xsl:text>, </xsl:text>
+        <xsl:value-of select="."/>
+    </xsl:template>
+
+    <xsl:template match="instructor[1]">
+        <xsl:value-of select="."/>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/src/tree-view/xml-tree-data-provider.ts
+++ b/src/tree-view/xml-tree-data-provider.ts
@@ -37,10 +37,10 @@ export class XmlTreeDataProvider implements TreeDataProvider<any> {
         const enableMetadata = Configuration.enableXmlTreeViewMetadata;
         const enableSync = Configuration.enableXmlTreeViewCursorSync;
 
-        const treeItem = new TreeItem(element.localName);
+        const treeItem = new TreeItem((<Element>element).localName);
 
         if (!this._xmlTraverser.isElement(element)) {
-            treeItem.label = `${element.localName} = "${element.nodeValue}"`;
+            treeItem.label = `${(<Element>element).localName} = "${element.nodeValue}"`;
         }
 
         else if (enableMetadata) {

--- a/src/xslt/index.ts
+++ b/src/xslt/index.ts
@@ -1,0 +1,2 @@
+export * from "./xslt-apply";
+export * from "./xslt-transform";

--- a/src/xslt/schema.d.ts
+++ b/src/xslt/schema.d.ts
@@ -1,0 +1,1 @@
+declare module 'xslt-processor';

--- a/src/xslt/xslt-apply.ts
+++ b/src/xslt/xslt-apply.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from "fs";
+import { window, workspace, ViewColumn } from "vscode";
+import { XSLTTransform } from "./xslt-transform";
+
+export async function runXSLTTransform () {
+    const xsltFile = await window.showOpenDialog(
+        {
+            canSelectFiles: true,
+            canSelectFolders: false,
+            canSelectMany: false,
+            filters: {
+                "XSLT" : ["xsl", "xslt"]
+            }
+        }
+    );
+    if (window.activeTextEditor !== undefined && xsltFile !== undefined) {
+        const xml = window.activeTextEditor.document.getText();
+        const xslt = readFileSync(xsltFile[0].fsPath).toString();
+        try {
+            const result = new XSLTTransform(xml, xslt).apply();
+            const textDoc = await workspace.openTextDocument({
+                    content: result,
+                    language: "xml"
+            });
+
+            window.showTextDocument(textDoc, ViewColumn.Beside);
+
+            const web = window.createWebviewPanel("transformPreview", "XSLT Results", ViewColumn.Beside, { });
+            web.webview.html = result;
+
+        }
+        catch (e) {
+            window.showErrorMessage(e);
+        }
+    }
+    else {
+        window.showErrorMessage("An error occurred while accessing the XML and/or XSLT source files.");
+    }
+}

--- a/src/xslt/xslt-transform.ts
+++ b/src/xslt/xslt-transform.ts
@@ -1,0 +1,18 @@
+import { xmlParse, xsltProcess } from "xslt-processor";
+
+export class XSLTTransform {
+    private _xml: string;
+    private _xslt: string;
+    constructor(xml: string, xslt: string) {
+        this._xml = xml;
+        this._xslt = xslt;
+    }
+    public apply(): string {
+        try {
+            return xsltProcess(xmlParse(this._xml), xmlParse(this._xslt));
+        }
+        catch (e) {
+            throw new Error(e);
+        }
+    }
+}


### PR DESCRIPTION
Addresses #93 to a certain extent.

I was in the process of building my own extension for XSLT transformations, but thought it would be better to contribute to this extension.

When inside an XML file, you can pull up the command palette, and search for "XML Tools: Run XSLT Transformation" (or just "Run XSLT Transformation"). It will open a dialog window to select an XSLT file. Once selected it will transform the XML, open the results to the right, and then open a web view to the right of that, trying to display a rendered version.

The VSCode version had to be updated in order to use the web view control and the "BESIDE" enum for positioning of the opened window.

Two things I'd like to eventually see added: 1.) a setting for whether or not to open the web view; 2.) have the XSLT selection in the command palette rather than an open dialog.