### PR TITLE
fix #206 Allow custom xqueryExecutionArguments ordering

### DIFF
--- a/src/xquery-execution/commands/executeXQuery.ts
+++ b/src/xquery-execution/commands/executeXQuery.ts
@@ -78,7 +78,7 @@ export async function executeXQuery(editor: TextEditor, edit: TextEditorEdit): P
 
     for (let i = 0; i < args.length; i++) {
         if (i > 0) {
-            if (args[i - 1].search(/out|result/)) {
+            if (args[i].search(/out|result/) !== -1) {
                 outputPath = args[i];
                 outputPathPos = i;
             }


### PR DESCRIPTION
These changes fix the behavior described in #206.

String.search() returns -1 when no match is found, not false.

Matching args[i-1] presented the wrong preset for the prompt for the output argument and save the wrong index for outputPath.