### PR TITLE
fix: prevent negative indentation

### DIFF
--- a/src/formatting/formatters/v2-xml-formatter.ts
+++ b/src/formatting/formatters/v2-xml-formatter.ts
@@ -291,7 +291,7 @@ export class V2XmlFormatter implements XmlFormatter {
     }
 
     private _getIndent(options: XmlFormattingOptions, indentLevel: number): string {
-        return ((options.editorOptions.insertSpaces) ? " ".repeat(options.editorOptions.tabSize) : "\t").repeat(indentLevel);
+        return ((options.editorOptions.insertSpaces) ? " ".repeat(options.editorOptions.tabSize) : "\t").repeat(Math.max(indentLevel, 0));
     }
 
     private _removeTrailingNonBreakingWhitespace(text: string): string {


### PR DESCRIPTION
When trying to format certain XML files I'd get the error below.
It appears it was being caused by the indent value being `-1` for some weird reason (the XML was definitely valid). 
This PR is a quick fix to avoid this from happening.

```
[2020-07-06 20:05:20.839] [exthost] [error] [DotJoshJohnson.xml] provider FAILED
[2020-07-06 20:05:20.840] [exthost] [error] RangeError: Invalid count value
	at String.repeat (<anonymous>)
	at V2XmlFormatter._getIndent (/home/adam/.vscode/extensions/dotjoshjohnson.xml-2.5.0/out/formatting/formatters/v2-xml-formatter.js:208:106)
	at V2XmlFormatter.formatXml (/home/adam/.vscode/extensions/dotjoshjohnson.xml-2.5.0/out/formatting/formatters/v2-xml-formatter.js:169:39)
	at XmlFormattingEditProvider.provideDocumentRangeFormattingEdits (/home/adam/.vscode/extensions/dotjoshjohnson.xml-2.5.0/out/formatting/xml-formatting-edit-provider.js:39:41)
	at XmlFormattingEditProvider.provideDocumentFormattingEdits (/home/adam/.vscode/extensions/dotjoshjohnson.xml-2.5.0/out/formatting/xml-formatting-edit-provider.js:12:21)
	at /snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:681:526
	at /snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:52:136
	at new Promise (<anonymous>)
	at Object.t.asPromise (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:52:108)
	at P.provideDocumentFormattingEdits (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:681:497)
	at /snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:701:285
	at e._withAdapter (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:695:632)
	at e.$provideDocumentFormattingEdits (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:701:263)
	at e._doInvokeHandler (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:804:1013)
	at e._invokeHandler (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:804:705)
	at e._receiveRequest (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:803:293)
	at e._receiveOneMessage (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:802:156)
	at /snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:800:416
	at e.fire (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:46:242)
	at v.fire (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:239:274)
	at /snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:975:649
	at e.fire (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:46:242)
	at v.fire (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:239:274)
	at t.PersistentProtocol._receiveMessage (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:243:629)
	at /snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:240:824
	at e.fire (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:46:242)
	at p.acceptChunk (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:236:737)
	at /snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:236:89
	at Socket.t (/snap/code/35/usr/share/code/resources/app/out/vs/workbench/services/extensions/node/extensionHostProcess.js:245:185)
	at Socket.emit (events.js:203:13)
	at addChunk (_stream_readable.js:295:12)
	at readableAddChunk (_stream_readable.js:276:11)
	at Socket.Readable.push (_stream_readable.js:210:10)
	at Pipe.onStreamRead (internal/stream_base_commons.js:166:17)
```